### PR TITLE
Ajax call next queue item (faster queues)

### DIFF
--- a/SteamDiscoveryQueueAutoSkipper.user.js
+++ b/SteamDiscoveryQueueAutoSkipper.user.js
@@ -21,15 +21,16 @@
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
 	You may obtain a copy of the License at
-	
+
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 	Unless required by applicable law or agreed to in writing, software
 	distributed under the License is distributed on an "AS IS" BASIS,
 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 	See the License for the specific language governing permissions and
 	limitations under the License.
 */
+var load,execute,loadAndExecute;load=function(a,b,c){var d;d=document.createElement("script"),d.setAttribute("src",a),b!=null&&d.addEventListener("load",b),c!=null&&d.addEventListener("error",c),document.body.appendChild(d);return d},execute=function(a){var b,c;typeof a=="function"?b="("+a+")();":b=a,c=document.createElement("script"),c.textContent=b,document.body.appendChild(c);return c},loadAndExecute=function(a,b){return load(a,function(){return execute(b)})};
 
 var page = document.getElementsByTagName("BODY")[0].innerHTML;
 
@@ -39,67 +40,86 @@ if (page.length < 100
 {
 	location.reload();
 }
+else{
+	loadAndExecute("https://code.jquery.com/jquery-2.2.3.min.js", function() {
 
-function click (obj)
-{
-	var evObj = new MouseEvent ('click');
-	obj.dispatchEvent (evObj);
-
-	window.addEventListener ('load', function() {
-		click (obj);
-	});
-}
-
-var btn = document.getElementsByClassName ("btn_next_in_queue")[0];
-
-if (btn)
-{
-	var btn_text = btn.getElementsByTagName ("span")[0];
-	var btn_subtext = document.getElementsByClassName ("queue_sub_text")[0];
-	if (btn_text)
-	{
-		if (btn_subtext)
+		function click (obj)
 		{
-			btn_text.textContent = "Loading next item...";
-			btn_text.appendChild (document.createElement ("br"));
-			btn_text.appendChild (btn_subtext);
+			var evObj = new MouseEvent ('click');
+			obj.dispatchEvent (evObj);
+
+			window.addEventListener ('load', function() {
+				click (obj);
+			});
 		}
-		else
-		{
-			btn_text.textContent = "Finishing Queue...";
-		}
-	}
-	click (btn);
-}
 
-var app_agegate = document.getElementById ("app_agegate");
-if (app_agegate)
-{
-	var btn_medium = app_agegate.getElementsByClassName ("btn_medium");
-	if (btn_medium)
-	{
-		for (i = 0; i < btn_medium.length; i++)
+		var btn = document.getElementsByClassName ("btn_next_in_queue")[0];
+
+		if (btn)
 		{
-			if (btn_medium[i].textContent.includes ("Continue"))
+			var btn_text = btn.getElementsByTagName ("span")[0];
+			var btn_subtext = document.getElementsByClassName ("queue_sub_text")[0];
+			if (btn_text)
 			{
-				click (btn_medium[i]);
+				if (btn_subtext)
+				{
+					btn_text.textContent = "Loading next item...";
+					btn_text.appendChild (document.createElement ("br"));
+					btn_text.appendChild (btn_subtext);
+				}
+				else
+				{
+					btn_text.textContent = "Finishing Queue...";
+				}
+			}
+			function nextInQueue(){
+				$.ajax({
+					url: $('#next_in_queue_form').attr("action"),
+					data: $('#next_in_queue_form').serialize(),
+					method: "POST",
+					success: function(data){
+						if ($('#next_in_queue_form',data).length){
+							$('#next_in_queue_form').parent().html($('#next_in_queue_form',data).parent().html());
+							nextInQueue();
+						}else{
+							location.replace($('#next_in_queue_form').attr("action"));
+						}
+					}
+				});
+			}
+			nextInQueue();
+		}
+
+		var app_agegate = document.getElementById ("app_agegate");
+		if (app_agegate)
+		{
+			var btn_medium = app_agegate.getElementsByClassName ("btn_medium");
+			if (btn_medium)
+			{
+				for (i = 0; i < btn_medium.length; i++)
+				{
+					if (btn_medium[i].textContent.includes ("Continue"))
+					{
+						click (btn_medium[i]);
+					}
+				}
 			}
 		}
-	}
-}
 
-var ageYear = document.getElementById ("ageYear");
-if (ageYear)
-{
-	ageYear.value = 1985;
-	if (DoAgeGateSubmit)
-	{
-		DoAgeGateSubmit();
-	}
-}
+		var ageYear = document.getElementById ("ageYear");
+		if (ageYear)
+		{
+			ageYear.value = 1985;
+			if (DoAgeGateSubmit)
+			{
+				DoAgeGateSubmit();
+			}
+		}
 
-var refresh_queue_btn = document.getElementById ("refresh_queue_btn");
-if (refresh_queue_btn && (Number (document.getElementsByClassName ('subtext')[0].innerHTML.substring(12,13)) >= 1))
-{
-	click (refresh_queue_btn);
+		var refresh_queue_btn = document.getElementById ("refresh_queue_btn");
+		if (refresh_queue_btn && (Number (document.getElementsByClassName ('subtext')[0].innerHTML.substring(12,13)) >= 1))
+		{
+			click (refresh_queue_btn);
+		}
+	});
 }

--- a/SteamDiscoveryQueueAutoSkipper.user.js
+++ b/SteamDiscoveryQueueAutoSkipper.user.js
@@ -84,6 +84,9 @@ else{
 						}else{
 							location.replace($('#next_in_queue_form').attr("action"));
 						}
+					},
+					error: function(){
+						location.replace($('#next_in_queue_form').attr("action"));
 					}
 				});
 			}


### PR DESCRIPTION
The Comparison looks completely different from whats really been changed,

all i have done is add the following lines:
* [#33](https://github.com/RedSparr0w/SteamDiscoveryQueueAutoSkipper/blob/cde9b592a101e3117182ca90cb7d1971a0e63802/SteamDiscoveryQueueAutoSkipper.user.js#L33)	|	define `loadAndExecute` function
* [#43-44](https://github.com/RedSparr0w/SteamDiscoveryQueueAutoSkipper/blob/cde9b592a101e3117182ca90cb7d1971a0e63802/SteamDiscoveryQueueAutoSkipper.user.js#L43-L44)	|	`loadAndExecute` jquery
* [#75-93](https://github.com/RedSparr0w/SteamDiscoveryQueueAutoSkipper/blob/cde9b592a101e3117182ca90cb7d1971a0e63802/SteamDiscoveryQueueAutoSkipper.user.js#L75-L93)	|	make ajax call
* [#127](https://github.com/RedSparr0w/SteamDiscoveryQueueAutoSkipper/blob/cde9b592a101e3117182ca90cb7d1971a0e63802/SteamDiscoveryQueueAutoSkipper.user.js#L127-L128)	|	Close `loadAndExecute()`

This makes the code alot faster due to not having to load all the extra images/scripts etc for each Game/App in the queue

If the "next" item in the queue does not have the  `#next_in_queue_form` the page will load the next page rather than get it with ajax, due it may be "age restricted" or queue may be finished